### PR TITLE
Add hash field in GetTransaction & GetTransactions

### DIFF
--- a/src/client/TonClient.ts
+++ b/src/client/TonClient.ts
@@ -113,14 +113,12 @@ export class TonClient {
      * Get transactions
      * @param address address
      */
-    async getTransactions(address: Address, opts: { limit: number, lt?: string, hash?: string, to_lt?: string, inclusive?: boolean }) {
+    async getTransactions(address: Address, opts: { limit: number, lt?: string, hash?: string, to_lt?: string, inclusive?: boolean }): Promise<(Transaction & {
+        hash: String;
+    })[]> {
         // Fetch transactions
         let tx = await this.#api.getTransactions(address, opts);
-        let res: Transaction[] = [];
-        for (let r of tx) {
-            res.push(loadTransaction(Cell.fromBoc(Buffer.from(r.data, 'base64'))[0].beginParse()));
-        }
-        return res;
+        return tx.map<Transaction & { hash: String; }>(t => ({ hash: t.transaction_id.hash, ...loadTransaction(Cell.fromBoc(Buffer.from(t.data, 'base64'))[0].beginParse()) }))
     }
 
     /**
@@ -130,13 +128,9 @@ export class TonClient {
      * @param hash transaction hash
      * @returns transaction or null if not exist
      */
-    async getTransaction(address: Address, lt: string, hash: string) {
+    async getTransaction(address: Address, lt: string, hash: string): Promise<Transaction & { hash: string } | null> {
         let res = await this.#api.getTransaction(address, lt, hash);
-        if (res) {
-            return loadTransaction(Cell.fromBoc(Buffer.from(res.data, 'base64'))[0].beginParse());
-        } else {
-            return null;
-        }
+        return res ? { hash: res.transaction_id.hash, ...loadTransaction(Cell.fromBoc(Buffer.from(res.data, 'base64'))[0].beginParse()) } : null;
     }
 
     /**


### PR DESCRIPTION
## Describe your changes
Add transaction hash field for :
* TonClient 
   * GetTransaction -> {hash:string} & Transaction 
   * GetTransactions -> {hash:string} & Transaction 
   
API is still compatible with the old one.

## Issue ticket number and link
I need to scan all of the transactions and store the ref to track the changes, exposing the hash & lt at the same time is the only way to do that.
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [x] Will this be part of a product update? If yes, please write one phrase about this update.


Update Phrases : 
* add transaction hash for TonClient in getTransaction & getTransactions API.
