### PR TITLE
Add `sendOrderWithoutSecretKey` method to `MultisigWallet`

### DIFF
--- a/src/multisig/MultisigWallet.spec.ts
+++ b/src/multisig/MultisigWallet.spec.ts
@@ -8,7 +8,7 @@ import {
     ContractProvider,
     MessageRelaxed,
 } from '@ton/core';
-import { getSecureRandomBytes, keyPairFromSeed } from '@ton/crypto';
+import { getSecureRandomBytes, keyPairFromSeed, sign } from '@ton/crypto';
 import { testAddress, ContractSystem, Treasure } from '@ton/emulator';
 import { MultisigWallet } from './MultisigWallet';
 import { MultisigOrderBuilder } from './MultisigOrderBuilder';
@@ -253,6 +253,57 @@ describe('MultisigWallet', () => {
         );
 
         await multisig.sendOrder(orderBuilder.build(), secretKeys[3], provider);
+        let txs = await system.run();
+        expect(txs).toHaveLength(1);
+        if (txs[0].description.type == 'generic') {
+            expect(txs[0].description.aborted).toBeFalsy;
+        }
+    });
+
+    it('should accept orders sent by `sendWithoutSecretKey` method', async () => {
+        let multisig = new MultisigWallet(publicKeys, 0, 123, 2);
+        let provider = createProvider(multisig);
+        await multisig.deployInternal(treasure, 10000000000n);
+        await system.run();
+
+        let orderBuilder = new MultisigOrderBuilder(123);
+        orderBuilder.addMessage(
+            createInternalMessage(
+                true,
+                testAddress('address1'),
+                1000000000n,
+                Cell.EMPTY
+            ),
+            3
+        );
+        orderBuilder.addMessage(
+            createInternalMessage(
+                true,
+                testAddress('address2'),
+                0n,
+                beginCell().storeUint(3, 123).endCell()
+            ),
+            3
+        );
+        orderBuilder.addMessage(
+            createInternalMessage(
+                true,
+                testAddress('address1'),
+                2000000000n,
+                Cell.EMPTY
+            ),
+            3
+        );
+
+        const order = orderBuilder.build();
+
+        const signature = sign(order.toCell(3).hash(), secretKeys[3]);
+        await multisig.sendOrderWithoutSecretKey(
+            orderBuilder.build(),
+            signature,
+            3,
+            provider
+        );
         let txs = await system.run();
         expect(txs).toHaveLength(1);
         if (txs[0].description.type == 'generic') {

--- a/src/multisig/MultisigWallet.ts
+++ b/src/multisig/MultisigWallet.ts
@@ -162,6 +162,31 @@ export class MultisigWallet {
         await provider.external(cell);
     }
 
+    public async sendOrderWithoutSecretKey(
+        order: MultisigOrder,
+        signature: Buffer,
+        ownerId: number,
+        provider?: ContractProvider
+    ) {
+        if (!provider && !this.provider) {
+            throw Error(
+                'you must specify provider if there is no such property in MultisigWallet instance'
+            );
+        }
+        if (!provider) {
+            provider = this.provider!;
+        }
+
+        let cell = order.toCell(ownerId);
+
+        cell = beginCell()
+            .storeBuffer(signature)
+            .storeSlice(cell.asSlice())
+            .endCell();
+
+        await provider.external(cell);
+    }
+
     public getOwnerIdByPubkey(publicKey: Buffer) {
         for (const [key, value] of this.owners) {
             if (value.subarray(0, 32).equals(publicKey)) {


### PR DESCRIPTION
It is useful in user interfaces where the website doesn't have access to user's secret key.