### PR TITLE
Add some missed exports.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,8 @@ export * from '@ton/core';
 // toncenter Client
 //
 
-export { HttpApi } from './client/api/HttpApi';
-export { TonClient } from './client/TonClient';
+export { HttpApi, HttpApiParameters } from './client/api/HttpApi';
+export { TonClient, TonClientParameters } from './client/TonClient';
 
 //
 // API V4 Client


### PR DESCRIPTION
Sometimes there is a need to define params as an object before passing it to a constructor:

```typescript
const params: TonClientParameters = {
  // params here
}
```