### PR TITLE
Support for `tvm.stackEntryList`

### DIFF
--- a/src/client/TonClient.ts
+++ b/src/client/TonClient.ts
@@ -346,6 +346,8 @@ function parseStackEntry(s: any): TupleItem {
             return { type: 'cell', cell: Cell.fromBase64(s.cell) };
         case 'tvm.stackEntryTuple':
             return { type: 'tuple', items: s.tuple.elements.map(parseStackEntry) };
+        case 'tvm.stackEntryList':
+            return { type: 'list', items: s.list.elements.map(parseStackEntry) }
         default:
             throw Error("Unsupported item type: " + s["@type"]);
     }


### PR DESCRIPTION
Added case to `parseStackEntry` method in `TonClient` class.