### PR TITLE
Provide access to the axios instance

### DIFF
--- a/src/client/TonClient.ts
+++ b/src/client/TonClient.ts
@@ -54,8 +54,7 @@ export type TonClientParameters = {
 
 export class TonClient {
     readonly parameters: TonClientParameters;
-
-    protected api: HttpApi;
+    readonly api: HttpApi;
 
     constructor(parameters: TonClientParameters) {
         this.parameters = {

--- a/src/client/api/HttpApi.ts
+++ b/src/client/api/HttpApi.ts
@@ -188,6 +188,7 @@ interface HttpApiResolvedParameters extends HttpApiParameters {
 }
 
 export class HttpApi {
+    readonly axios: typeof axios = axios;
     readonly endpoint: string;
     readonly cache: TonCache;
 


### PR DESCRIPTION
Motivation: TON endpoints are really unstable sometimes and often respond with 5xx HTTP error, we need access to the axios instance making all the request in order to apply general error processing logic.

Example of the solution requiring an axios instance: https://www.npmjs.com/package/axios-retry