### PR TITLE
Wallet id deserializer fix

### DIFF
--- a/src/wallets/v5r1/WalletV5R1WalletId.ts
+++ b/src/wallets/v5r1/WalletV5R1WalletId.ts
@@ -67,7 +67,7 @@ export function loadWalletIdV5R1(value: bigint | Buffer | Slice, networkGlobalId
     const val = new BitReader(
         new BitString(
             typeof value === 'bigint' ?
-                Buffer.from(value.toString(16), 'hex') :
+                Buffer.from(value.toString(16).padStart(8, '0'), 'hex') :
                 value instanceof Slice ? value.loadBuffer(4) : value,
             0,
             32


### PR DESCRIPTION
# Fix

WalletId deserializer performed parsing
from integer value without proper alignment to 32 bit boundary.