### PR TITLE
chore: use semver range for axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "typescript": "^5.6.3"
     },
     "dependencies": {
-        "axios": "1.15.0",
+        "axios": "^1.15.0",
         "dataloader": "^2.0.0",
         "zod": "^3.21.4"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1591,7 +1591,7 @@ __metadata:
     "@ton/test-utils": ^0.12.0
     "@types/jest": ^29.5.12
     "@types/node": ^20.11.30
-    axios: 1.15.0
+    axios: ^1.15.0
     dataloader: ^2.0.0
     jest: ^29.7.0
     release-it: ^17.1.1
@@ -1770,6 +1770,15 @@ __metadata:
   version: 2.0.0
   resolution: "abbrev@npm:2.0.0"
   checksum: 0e994ad2aa6575f94670d8a2149afe94465de9cedaaaac364e7fb43a40c3691c980ff74899f682f4ca58fa96b4cbd7421a015d3a6defe43a442117d7821a2f36
+  languageName: node
+  linkType: hard
+
+"agent-base@npm:6":
+  version: 6.0.2
+  resolution: "agent-base@npm:6.0.2"
+  dependencies:
+    debug: 4
+  checksum: f52b6872cc96fd5f622071b71ef200e01c7c4c454ee68bc9accca90c98cfb39f2810e3e9aa330435835eedc8c23f4f8a15267f67c6e245d2b33757575bdac49d
   languageName: node
   linkType: hard
 
@@ -1988,14 +1997,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.15.0":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
+"axios@npm:^1.15.0":
+  version: 1.16.1
+  resolution: "axios@npm:1.16.1"
   dependencies:
-    follow-redirects: ^1.15.11
+    follow-redirects: ^1.16.0
     form-data: ^4.0.5
+    https-proxy-agent: ^5.0.1
     proxy-from-env: ^2.1.0
-  checksum: 95a8455554867a083ab3772fcadba42a22ec4bb546dccc66011556d837a07e544ae006675a30a5c43453f3e37e7c0982e934cec482c06b75abead2a2c157448a
+  checksum: 4b5daf07ed09e67d1884a98291023bd80a52854d705f6577eaa92ccc0c10b27df533e8c63d50cb3a321ce0efe4251760cdfb5eaa79c9d940d301914b3df9ddb5
   languageName: node
   linkType: hard
 
@@ -3280,13 +3290,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.11":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
+"follow-redirects@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 20bf55e9504f59e6cc3743ba27edb2ebf41edea1baab34799408f2c050f73f0c612728db21c691276296d2795ea8a812dc532a98e8793619fcab91abe06d017f
+  checksum: e90dce4607b1f6b8b9883287f912585573c19088209ad82341d550a795b4ba514522b73b1b340cf618279df27975cd46504d09149be60291ba6767384c1fd8f8
   languageName: node
   linkType: hard
 
@@ -3808,6 +3818,16 @@ __metadata:
     quick-lru: ^5.1.1
     resolve-alpn: ^1.2.0
   checksum: e95e55e22c6fd61182ce81fecb9b7da3af680d479febe8ad870d05f7ebbc9f076e455193766f4e7934e50913bf1d8da3ba121fb5cd2928892390b58cf9d5c509
+  languageName: node
+  linkType: hard
+
+"https-proxy-agent@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "https-proxy-agent@npm:5.0.1"
+  dependencies:
+    agent-base: 6
+    debug: 4
+  checksum: 571fccdf38184f05943e12d37d6ce38197becdd69e58d03f43637f7fa1269cf303a7d228aa27e5b27bbd3af8f09fd938e1c91dcfefff2df7ba77c20ed8dfc765
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pinning the version of your dependencies, if you are the library provider, is not the best solution to security-related issues. On the contrary, it makes it more difficult to resolve problems when your dependencies encounter issues.

For example, the current version of `axios` has an issue: [GHSA-q8qp-cvcw-x6jj](https://github.com/advisories/GHSA-q8qp-cvcw-x6jj):

```
ton % yarn npm audit
└─ axios: 1.15.0
   ├─ ID: 1118607
   ├─ Issue: Axios has prototype pollution read-side gadgets in HTTP adapter that allow credential injection and request hijacking
   ├─ URL: https://github.com/advisories/GHSA-q8qp-cvcw-x6jj
   ├─ Severity: high
   ├─ Vulnerable Versions: >=1.0.0 <1.15.2
   ├─ Patched Versions: >=1.15.2
   ├─ Via: axios
   └─ Recommendation: Upgrade to version 1.15.2 or later
```

In my project, I would simply update `axios` and the problem would be sorted. But because the version is explicitly specified, I’ll have to use [`overrides`](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#overrides)

Additionally, this creates a problem with duplicate dependencies, as the version of `axios` required by your package will be installed separately, even if the project specifies `^1.15.0`. This means that if the project uses `axios` version `^1.16.0`, it will encounter issues when building the TypeScript project


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency versioning to allow installation of compatible minor releases, enabling access to potential security patches and improvements within the same major version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ton-org/ton/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->